### PR TITLE
Ensure variables get moved to config for Drupal 7 upgrades. Fixes #2

### DIFF
--- a/nodereference_url.install
+++ b/nodereference_url.install
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * Move nodereference_url settings from variables to config.
+ */
+function nodereference_url_update_1000() {
+  $config = config('nodereference_url.settings');
+  $config->set('url_paths', update_variable_get('nodereference_url_paths', array('node/add/%type/%nid')));
+  $config->save();
+
+  update_variable_del('nodereference_url_paths');
+}


### PR DESCRIPTION
This ensures that url_paths has a default value set and that the Drupal 7 value moves to Backdrop if the site is upgrading from D7.